### PR TITLE
Add convex hull computation for collision geometries.

### DIFF
--- a/robot_designer_plugin/interface/geometries.py
+++ b/robot_designer_plugin/interface/geometries.py
@@ -136,6 +136,8 @@ def draw(layout, context):
             column = row.column(align=True)
             collision.GenerateAllCollisionMeshes.place_button(column, infoBox=infoBox)
             collision.GenerateCollisionMesh.place_button(column, infoBox=infoBox)
+            collision.GenerateAllCollisionConvexHull.place_button(column, infoBox=infoBox)
+            collision.GenerateCollisionConvexHull.place_button(column, infoBox=infoBox)
 
             box.row()
             infoBox.draw_info()

--- a/robot_designer_plugin/operators/collision.py
+++ b/robot_designer_plugin/operators/collision.py
@@ -272,10 +272,12 @@ class GenerateCollisionConvexHull(RDOperator):
             bm.to_mesh(collisionMesh)
             bm.free()
           
-            orig_object.name = target_name
+            exp_object.select = True
+            
+            exp_object.RobotEditor.tag = 'COLLISION'
+            self.logger.debug("Created mesh: %s", exp_object.name)
           
-            context.active_object.RobotEditor.tag = 'COLLISION'
-            self.logger.debug("Created mesh: %s", bpy.context.active_object.name)
+            orig_object.name = target_name
             
             bpy.ops.object.select_all(action='DESELECT')
             


### PR DESCRIPTION
This would add an alternative for automatically generating collision shapes for a robot model using convex hulls. Includes both batch operation (compute convex hulls for all meshes in a model) and per-mesh convex hull computation.
