### PR TITLE
Bug fix for NRRPLT-5842

### DIFF
--- a/robot_designer_plugin/operators/segments.py
+++ b/robot_designer_plugin/operators/segments.py
@@ -218,7 +218,8 @@ class AssignParentSegment(RDOperator):
 class ImportBlenderArmature(RDOperator):
     """
     :term:`operator` for converting a :term:`armature` into a :term:`model`
-
+    This operator does NOT currently support import of visuals, collision shapes
+    or kinematic constraints.
 
     """
     bl_idname = config.OPERATOR_PREFIX + "importnative"

--- a/robot_designer_plugin/operators/segments.py
+++ b/robot_designer_plugin/operators/segments.py
@@ -236,11 +236,6 @@ class ImportBlenderArmature(RDOperator):
         bone = bpy.context.active_bone
         parent = bpy.context.active_bone.parent
         children = bpy.context.active_bone.children
-        bone.use_connect = False
-        for i in children:
-            i.use_connect = False
-
-        bone.length = 1
 
         if parent is not None:
             m = parent.matrix.inverted() * bone.matrix


### PR DESCRIPTION
This fixes the import operator that adds robot designer-specific attributes to Blender bone instances on importing a native Blender rig to the robot designer.
