### PR TITLE
Physics Frames Handling & Conversion of Vertex Weighted Meshes

### DIFF
--- a/robot_designer_plugin/export/sdf/sdf_export.py
+++ b/robot_designer_plugin/export/sdf/sdf_export.py
@@ -307,8 +307,9 @@ def create_sdf(operator: RDOperator, context, filepath: str, meshpath: str, topl
         operator.logger.info(" joint type'%s'" % child.joint.type)
 
         # Add properties
+        armature = context.active_object
         connected_meshes = [mesh.name for mesh in bpy.data.objects if
-                            mesh.type == 'MESH' and mesh.parent_bone == segment.name]
+                            mesh.type == 'MESH' and mesh.parent_bone == segment.name and mesh.parent == armature]
         # if len(connected_meshes) > 0:
         #     child.link.name = connected_meshes[0]
         # else:
@@ -316,7 +317,6 @@ def create_sdf(operator: RDOperator, context, filepath: str, meshpath: str, topl
         #     # todo: the RobotDesigner does not have the concept of
         #     # links further it is possible to have
         #     # todo: several meshes assigned to the same bone
-        #     # todo: solutions add another property to a bone or
         #     # todo: solutions add another property to a bone or
         #     # chose the name from the list of connected meshes
         for mesh in connected_meshes:

--- a/robot_designer_plugin/export/sdf/sdf_export.py
+++ b/robot_designer_plugin/export/sdf/sdf_export.py
@@ -388,16 +388,20 @@ def create_sdf(operator: RDOperator, context, filepath: str, meshpath: str, topl
             if bpy.data.objects[frame].parent_bone == segment.name:
                 pose_bone = context.active_object.pose.bones[segment.name]
 
+
                 # set mass
-                inertial.mass[0] = round(bpy.data.objects[frame].RobotEditor.dynamics.mass,4)
+                inertial.mass[0] = bpy.data.objects[frame].RobotEditor.dynamics.mass
+                if inertial.mass[0] <= 0.:
+                    raise ValueError("Mass of "+frame+" is not positive, but "+str(inertial.mass[0]))
+                # Ugly, to throw an exception here. But appending info_list did not print the info in the GUI.
 
                 # set inertia
-                inertial.inertia[0].ixx[0] = round(bpy.data.objects[frame].RobotEditor.dynamics.inertiaXX,4)
-                inertial.inertia[0].ixy[0] = round(bpy.data.objects[frame].RobotEditor.dynamics.inertiaXY,4)
-                inertial.inertia[0].ixz[0] = round(bpy.data.objects[frame].RobotEditor.dynamics.inertiaXZ,4)
-                inertial.inertia[0].iyy[0] = round(bpy.data.objects[frame].RobotEditor.dynamics.inertiaYY,4)
-                inertial.inertia[0].iyz[0] = round(bpy.data.objects[frame].RobotEditor.dynamics.inertiaYZ,4)
-                inertial.inertia[0].izz[0] = round(bpy.data.objects[frame].RobotEditor.dynamics.inertiaZZ,4)
+                inertial.inertia[0].ixx[0] = bpy.data.objects[frame].RobotEditor.dynamics.inertiaXX
+                inertial.inertia[0].ixy[0] = bpy.data.objects[frame].RobotEditor.dynamics.inertiaXY
+                inertial.inertia[0].ixz[0] = bpy.data.objects[frame].RobotEditor.dynamics.inertiaXZ
+                inertial.inertia[0].iyy[0] = bpy.data.objects[frame].RobotEditor.dynamics.inertiaYY
+                inertial.inertia[0].iyz[0] = bpy.data.objects[frame].RobotEditor.dynamics.inertiaYZ
+                inertial.inertia[0].izz[0] = bpy.data.objects[frame].RobotEditor.dynamics.inertiaZZ
 
                 # set inertial pose
                 pose = pose_bone.matrix.inverted() * context.active_object.matrix_world.inverted() * \

--- a/robot_designer_plugin/export/sdf/sdf_export.py
+++ b/robot_designer_plugin/export/sdf/sdf_export.py
@@ -386,6 +386,8 @@ def create_sdf(operator: RDOperator, context, filepath: str, meshpath: str, topl
             inertial = child.link.inertial[0]
             print(inertial, inertial.__dict__)
             if bpy.data.objects[frame].parent_bone == segment.name:
+                pose_bone = context.active_object.pose.bones[segment.name]
+
                 # set mass
                 inertial.mass[0] = round(bpy.data.objects[frame].RobotEditor.dynamics.mass,4)
 
@@ -404,8 +406,9 @@ def create_sdf(operator: RDOperator, context, filepath: str, meshpath: str, topl
                 frame_pose_xyz = list_to_string([i * j for i, j in zip(pose.translation, blender_scale_factor)])
                 frame_pose_rpy = list_to_string(pose.to_euler())
 
-                visual.pose.append(' '.join([frame_pose_xyz, frame_pose_rpy]))
-
+                # Wtf is that?
+                #visual.pose.append(' '.join([frame_pose_xyz, frame_pose_rpy]))
+                #
                 inertial.pose[0] = ' '.join([frame_pose_xyz, frame_pose_rpy])
 
         #

--- a/robot_designer_plugin/export/urdf/urdf_export.py
+++ b/robot_designer_plugin/export/urdf/urdf_export.py
@@ -277,6 +277,7 @@ def create_urdf(operator: RDOperator, context, base_link_name,
                 inertial.inertia.izz = round(bpy.data.objects[frame].RobotEditor.dynamics.inertiaZZ,4)
 
                 # set inertial pose
+                assert False, "FIXME: Use the matrix of the physics frame rather than intertiaTrans and inertiaRot!"
                 inertial.origin.xyz = list_to_string(bpy.data.objects[frame].RobotEditor.dynamics.inertiaTrans)
                 inertial.origin.rpy = list_to_string(bpy.data.objects[frame].RobotEditor.dynamics.inertiaRot)
 

--- a/robot_designer_plugin/interface/dynamics.py
+++ b/robot_designer_plugin/interface/dynamics.py
@@ -85,10 +85,12 @@ def draw(layout, context):
     menus.MassObjectMenu.putMenu(column, context)
     # create_geometry_selection(column, context)
     row = box.column(align=True)
-    dynamics.AssignPhysical.place_button(row,infoBox=infoBox)
-    dynamics.DetachPhysical.place_button(row,infoBox=infoBox)
     dynamics.CreatePhysical.place_button(row,infoBox=infoBox)
     dynamics.ComputePhysical.place_button(row,infoBox=infoBox)
+
+    #dynamics.AssignPhysical.place_button(row,infoBox=infoBox)
+    #dynamics.DetachPhysical.place_button(row,infoBox=infoBox)
+
 
     obj = getSingleObject(context)
     if obj and obj.RobotEditor.tag=="PHYSICS_FRAME":

--- a/robot_designer_plugin/interface/dynamics.py
+++ b/robot_designer_plugin/interface/dynamics.py
@@ -94,7 +94,7 @@ def draw(layout, context):
 
     obj = getSingleObject(context)
     if obj and obj.RobotEditor.tag=="PHYSICS_FRAME":
-        frame_name = global_properties.physics_frame_name.get(context.scene)
+        frame_name = obj.name
         box = layout.box()
         box.label("Properties", icon="MODIFIER")
         frame = bpy.data.objects[frame_name]
@@ -104,16 +104,8 @@ def draw(layout, context):
         row_t = box.row(align=True)
         row_r = box.row(align=True)
 
-        active_physics_frame = global_properties.physics_frame_name.get(context.scene)
-
-        row_t.prop(bpy.data.objects[active_physics_frame], 'location', text="Translation")
-        row_r.prop(bpy.data.objects[active_physics_frame], 'rotation_euler', text="Rotation")
-
-        ## old
-
-        ## delete this from the roboteditor
-       # row_t.prop(frame.RobotEditor.dynamics, "inertiaTrans")
-       # row_r.prop(frame.RobotEditor.dynamics, "inertiaRot")
+        row_t.prop(bpy.data.objects[frame_name], 'location', text="Translation")
+        row_r.prop(bpy.data.objects[frame_name], 'rotation_euler', text="Rotation")
 
         row0 = box.row(align=True)
         row1 = box.row(align=True)

--- a/robot_designer_plugin/interface/dynamics.py
+++ b/robot_designer_plugin/interface/dynamics.py
@@ -88,6 +88,7 @@ def draw(layout, context):
     dynamics.AssignPhysical.place_button(row,infoBox=infoBox)
     dynamics.DetachPhysical.place_button(row,infoBox=infoBox)
     dynamics.CreatePhysical.place_button(row,infoBox=infoBox)
+    dynamics.ComputePhysical.place_button(row,infoBox=infoBox)
 
     obj = getSingleObject(context)
     if obj and obj.RobotEditor.tag=="PHYSICS_FRAME":

--- a/robot_designer_plugin/interface/dynamics.py
+++ b/robot_designer_plugin/interface/dynamics.py
@@ -81,45 +81,52 @@ def draw(layout, context):
                                                icon='VIEWZOOM',
                                                text='')
 
-    column = row.column(align=True)
-    menus.MassObjectMenu.putMenu(column, context)
+    #column = row.column(align=True)
+
+    #menus.MassObjectMenu.putMenu(column, context)
     # create_geometry_selection(column, context)
     row = box.column(align=True)
+
     dynamics.CreatePhysical.place_button(row,infoBox=infoBox)
     dynamics.ComputePhysical.place_button(row,infoBox=infoBox)
 
     #dynamics.AssignPhysical.place_button(row,infoBox=infoBox)
     #dynamics.DetachPhysical.place_button(row,infoBox=infoBox)
 
+    objs = [ o for o in context.active_object.children if o.RobotEditor.tag=='PHYSICS_FRAME' and o.parent_bone == single_segment.name ]
+    print (objs)
+    try:
+        obj, = objs
+        #obj = getSingleObject(context)
+        if obj and obj.RobotEditor.tag=="PHYSICS_FRAME":
+            frame_name = obj.name
+            box = layout.box()
+            box.label("Mass properties (" + single_segment.name + ")", icon="MODIFIER")
+            frame = bpy.data.objects[frame_name]
+            box.prop(frame.RobotEditor.dynamics, "mass")
+            box.separator()
 
-    obj = getSingleObject(context)
-    if obj and obj.RobotEditor.tag=="PHYSICS_FRAME":
-        frame_name = obj.name
-        box = layout.box()
-        box.label("Properties", icon="MODIFIER")
-        frame = bpy.data.objects[frame_name]
-        box.prop(frame.RobotEditor.dynamics, "mass")
-        box.separator()
+            row_t = box.row(align=True)
+            row_r = box.row(align=True)
 
-        row_t = box.row(align=True)
-        row_r = box.row(align=True)
+            row_t.prop(bpy.data.objects[frame_name], 'location', text="Translation")
+            row_r.prop(bpy.data.objects[frame_name], 'rotation_euler', text="Rotation")
 
-        row_t.prop(bpy.data.objects[frame_name], 'location', text="Translation")
-        row_r.prop(bpy.data.objects[frame_name], 'rotation_euler', text="Rotation")
-
-        row0 = box.row(align=True)
-        row1 = box.row(align=True)
-        row2 = box.row(align=True)
-        row3 = box.row(align=True)
-        row0.label("Inertia Matrix")
-        row1.prop(frame.RobotEditor.dynamics, "inertiaXX")
-        row2.prop(frame.RobotEditor.dynamics, "inertiaXY")
-        row3.prop(frame.RobotEditor.dynamics, "inertiaXZ")
-        row1.prop(frame.RobotEditor.dynamics, "inertiaXY")
-        row2.prop(frame.RobotEditor.dynamics, "inertiaYY")
-        row3.prop(frame.RobotEditor.dynamics, "inertiaYZ")
-        row1.prop(frame.RobotEditor.dynamics, "inertiaXZ")
-        row2.prop(frame.RobotEditor.dynamics, "inertiaYZ")
-        row3.prop(frame.RobotEditor.dynamics, "inertiaZZ")
+            row0 = box.row(align=True)
+            row1 = box.row(align=True)
+            row2 = box.row(align=True)
+            row3 = box.row(align=True)
+            row0.label("Inertia Matrix")
+            row1.prop(frame.RobotEditor.dynamics, "inertiaXX")
+            row2.prop(frame.RobotEditor.dynamics, "inertiaXY")
+            row3.prop(frame.RobotEditor.dynamics, "inertiaXZ")
+            row1.prop(frame.RobotEditor.dynamics, "inertiaXY")
+            row2.prop(frame.RobotEditor.dynamics, "inertiaYY")
+            row3.prop(frame.RobotEditor.dynamics, "inertiaYZ")
+            row1.prop(frame.RobotEditor.dynamics, "inertiaXZ")
+            row2.prop(frame.RobotEditor.dynamics, "inertiaYZ")
+            row3.prop(frame.RobotEditor.dynamics, "inertiaZZ")
+    except:
+        pass
 
     infoBox.draw_info()

--- a/robot_designer_plugin/interface/helpers.py
+++ b/robot_designer_plugin/interface/helpers.py
@@ -114,8 +114,10 @@ info_list = []
 def push_info(message_or_condition):
     # Check if list or tuple .. print only if condition is not met.
     if issubclass(message_or_condition, Condition):
-        info_list.append(message_or_condition.check()[1])
-        print(info_list)
+        ok, potential_error_message = message_or_condition.check()
+        if not ok:
+            info_list.append(potential_error_message)
+        #print(info_list)
     else:
         info_list.append(message_or_condition)
 

--- a/robot_designer_plugin/interface/main.py
+++ b/robot_designer_plugin/interface/main.py
@@ -97,12 +97,13 @@ class UserInterface(bpy.types.Panel):
             row = layout.row(align=True)
             global_properties.operator_debug_level.prop(bpy.context.scene,row, expand=True)
 
-        row = layout.row(align=True)
-        row.label("Set Mode")
-        if context.active_object:
-            row.operator("object.mode_set", text="Object Mode").mode = 'OBJECT'
-            if context.active_object.type == "ARMATURE":
-                row.operator("object.mode_set", text="Pose Mode").mode = 'POSE'
+        # M. Welter: Why is this needed? There is already a perfectly fine gui to switch modes, even in a prominent place, .
+        # row = layout.row(align=True)
+        # row.label("Set Mode")
+        # if context.active_object:
+        #     row.operator("object.mode_set", text="Object Mode").mode = 'OBJECT'
+        #     if context.active_object.type == "ARMATURE":
+        #         row.operator("object.mode_set", text="Pose Mode").mode = 'POSE'
 
 
         layout.separator()

--- a/robot_designer_plugin/interface/menus.py
+++ b/robot_designer_plugin/interface/menus.py
@@ -260,7 +260,7 @@ class MassObjectMenu(bpy.types.Menu, BaseMenu):
     obj_tag = global_properties.physics_type
     show_connected = global_properties.list_meshes
     blender_type = StringConstants.empty
-    quick_search = global_properties.physics_frame_name
+    #quick_search = None #global_properties.physics_frame_name
     operator_property = "frameName"
     operator = dynamics.SelectPhysical
     text = "Select mass object"
@@ -314,8 +314,8 @@ class MassObjectMenu(bpy.types.Menu, BaseMenu):
         cls.show_connected.prop(context.scene, row,  expand=True, icon_only=True)
         row.separator()
 
-        cls.quick_search.prop_search(bpy.context.scene, row,
-                                     bpy.data,'objects', icon='VIEWZOOM', text='')
+        #cls.quick_search.prop_search(bpy.context.scene, row,
+        #                             bpy.data,'objects', icon='VIEWZOOM', text='')
 
 
 

--- a/robot_designer_plugin/interface/segments.py
+++ b/robot_designer_plugin/interface/segments.py
@@ -37,6 +37,7 @@
 
 # Blender imports
 import bpy
+import bpy_types
 
 # RobotDesigner imports
 from .model import check_armature
@@ -65,28 +66,33 @@ def draw(layout, context):
         column = row.column(align=True)
         create_segment_selector(column, context)
 
-        box = layout.box()
-        row = box.row()
+        if (context.mode == "OBJECT" or context.mode == 'POSE'):
+            assert isinstance(context.active_bone, bpy_types.Bone), 'Given object or pose mode, we should get a bone here but we got '+str(type(context.active_bone))
 
-        if not context.active_bone.RobotEditor.RD_Bone:
-            row.label("Not a bone created by the Robot designer")
+            box = layout.box()
             row = box.row()
-            row.operator(segments.ImportBlenderArmature.bl_idname, text="Import native Blender segment")
-            row.prop(context.active_bone.RobotEditor, "RD_Bone")
 
+            if not context.active_bone.RobotEditor.RD_Bone:
+                row.label("Not a bone created by the Robot designer")
+                row = box.row()
+                row.operator(segments.ImportBlenderArmature.bl_idname, text="Import native Blender segment")
+                row.prop(context.active_bone.RobotEditor, "RD_Bone")
+
+            else:
+                row.label("Edit:")
+
+                global_properties.segment_tab.prop(bpy.context.scene,row,expand=True)
+
+                tab = global_properties.segment_tab.get(bpy.context.scene)
+
+                if tab == "kinematics":
+                    kinematics.draw(box, context)
+                elif tab == "dynamics":
+                    dynamics.draw(box, context)
+                elif tab == "controller":
+                    controllers.draw(box, context)
         else:
-            row.label("Edit:")
-
-            global_properties.segment_tab.prop(bpy.context.scene,row,expand=True)
-
-            tab = global_properties.segment_tab.get(bpy.context.scene)
-
-            if tab == "kinematics":
-                kinematics.draw(box, context)
-            elif tab == "dynamics":
-                dynamics.draw(box, context)
-            elif tab == "controller":
-                controllers.draw(box, context)
-
+            box = layout.box()
+            box.label("Must be in object or pose mode.")
     else:
         layout.operator(segments.CreateNewSegment.bl_idname, text="Create new base bone")

--- a/robot_designer_plugin/operators/dynamics.py
+++ b/robot_designer_plugin/operators/dynamics.py
@@ -50,7 +50,7 @@ from mathutils import Matrix
 from collections import defaultdict
 
 import bpy
-from bpy.props import StringProperty, FloatProperty
+from bpy.props import StringProperty, FloatProperty, BoolProperty
 
 # ######
 # RobotDesigner imports
@@ -222,7 +222,8 @@ class ComputePhysical(RDOperator):
     bl_idname = config.OPERATOR_PREFIX + "computephysicsframe"
     bl_label = "Compute mass properties from meshes"
 
-    density = FloatProperty(name="", precision=4, step=0.01, default=1.0)
+    density = FloatProperty(name="Density (kg/m^3)", precision=4, step=0.01, default=1.0)
+    from_visual_geometry = BoolProperty(name="From visual geometry")
 
     class SegmentAssociations(object):
         def __init__(self):
@@ -236,9 +237,9 @@ class ComputePhysical(RDOperator):
 
     def maybe_compute_and_assign_mass_props(self, bone, associations):
         assert associations.physics_frame is not None
-        if associations.collision:
+        if associations.collision and not self.from_visual_geometry:
             the_mesh = associations.collision
-        elif associations.visual:
+        elif associations.visual and self.from_visual_geometry:
             the_mesh = associations.visual
         else:
             return

--- a/robot_designer_plugin/operators/dynamics.py
+++ b/robot_designer_plugin/operators/dynamics.py
@@ -255,7 +255,7 @@ class ComputePhysical(RDOperator):
         Iunit = (1./12.*(len[1]**2 + len[2]**2),
                  1./12.*(len[0]**2 + len[2]**2),
                  1./12.*(len[0]**2 + len[1]**2))
-        print ("bone:", len, mass, Iunit, com)
+        print ("bone:", bone, len, mass, Iunit, com)
         d = associations.physics_frame.RobotEditor.dynamics
         d.inertiaXX = mass*Iunit[0]
         d.inertiaYY = mass*Iunit[1]
@@ -267,7 +267,8 @@ class ComputePhysical(RDOperator):
         #d.inertiaTrans = com
         #d.inertiaRot   = [0., 0., 0.]
         #print ("Setting matrix "+str(the_mesh.matrix_world))
-        associations.physics_frame.matrix_world = the_mesh.matrix_world
+        m_com = Matrix.Translation(com)
+        associations.physics_frame.matrix_world = the_mesh.matrix_world * m_com
 
 
     @RDOperator.OperatorLogger

--- a/robot_designer_plugin/operators/dynamics.py
+++ b/robot_designer_plugin/operators/dynamics.py
@@ -140,6 +140,7 @@ class SelectPhysical(RDOperator):
         return {'FINISHED'}
 
 
+
 # operator to assign selected physics frame to active bone
 @RDOperator.Preconditions(ModelSelected, SingleSegmentSelected, SingleMassObjectSelected)
 @PluginManager.register_class
@@ -179,12 +180,6 @@ class AssignPhysical(RDOperator):
         # frame.matrix_basis = armature_matrix*to_parent_matrix*from_parent_matrix*bone_matrix
         # frame.matrix_basis = parent_matrix*armature_matrix*bone_matrix
         return {'FINISHED'}
-
-    def invoke(self, context, event):
-        return context.window_manager.invoke_props_dialog(self)
-
-
-# operator to generate collision meshes for all assigned physics frames
 
 
 # operator to unassign selected physics frame

--- a/robot_designer_plugin/operators/dynamics.py
+++ b/robot_designer_plugin/operators/dynamics.py
@@ -159,7 +159,6 @@ class SelectPhysical(RDOperator):
     @RDOperator.Postconditions(ModelSelected)  # todo condition for physicframe
     def execute(self, context):
         arm = context.active_object
-        global_properties.physics_frame_name.set(context.scene, self.frameName)
 
         frame = bpy.data.objects[self.frameName]
 

--- a/robot_designer_plugin/operators/rigid_bodies.py
+++ b/robot_designer_plugin/operators/rigid_bodies.py
@@ -125,15 +125,29 @@ class AssignGeometry(RDOperator):
         # In order to get the child we have to jump through some hoops.
         obj = bpy.data.objects[global_properties.mesh_name.get(context.scene)]
         # Change the name depending on whether we want collision geometry or visual geometry.
+
+        def maybe_remove_prefix(s, prefix):
+            return s[len(prefix):] if s.startswith(prefix) else s
+
+        def maybe_remove_postfix(s, postfix):
+            return s[:-len(postfix)] if s.endswith(postfix) else s
+
+        new_name = obj.name
+        new_name = maybe_remove_postfix(new_name, '.001') # Heuristic to remove the suffix created by cloning.
+        # Heuristics to remove previously assigned prefixes.
+        # Since the prefix is regenerated it seems in order to try to remove the old prefix.
+        if len(new_name)>len('VIS_'):
+            new_name = maybe_remove_prefix(new_name, 'VIS_')
+        if len(new_name)>len('COL_'):
+            new_name = maybe_remove_prefix(new_name, 'COL_')
         if global_properties.assign_collision.get(context.scene) == True or obj.RobotEditor.tag == 'COLLISION':
             obj.RobotEditor.tag = 'COLLISION'
-            if not obj.name.startswith("COL_"):
-                obj.name = "COL_" + obj.name
+            new_name = "COL_" + new_name
         else:
             obj.RobotEditor.tag == 'DEFAULT'
-            if not obj.name.startswith("VIS_"):
-                obj.name = "VIS_" + obj.name
-        obj.RobotEditor.fileName = obj.name
+            new_name = "VIS_" + new_name
+        obj.name = new_name
+        obj.RobotEditor.fileName = new_name
         # Update the global reference to the selected mesh.
         global_properties.mesh_name.set(context.scene, obj.name)
         # This is just a boolean variable which is reset here to False. It helps

--- a/robot_designer_plugin/operators/segments.py
+++ b/robot_designer_plugin/operators/segments.py
@@ -638,6 +638,8 @@ class UpdateSegments(RDOperator):
             elif joint_axis == 'Z':
                 constraint.min_z = radians(min_rot)
                 constraint.max_z = radians(max_rot)
+        elif 'RobotEditorConstraint' in pose_bone.constraints:
+          pose_bone.constraints.remove(pose_bone.constraints['RobotEditorConstraint'])
         # -------------------------------------------------------
         bpy.ops.object.mode_set(mode=current_mode, toggle=False)
 

--- a/robot_designer_plugin/properties/globals.py
+++ b/robot_designer_plugin/properties/globals.py
@@ -101,6 +101,16 @@ class RDGlobals(PropertyGroupHandlerBase):
 
     @staticmethod
     def update_geometry_name(self, context):
+        """
+          On setting of the mesh_name, this function is invoked. It does two things:
+          Deselect every object which is not the active object.
+
+          Select the object whose name was set in mesh_name.
+
+          The rationale behind this was probably to allow for selection of a mesh
+          while the active_object of the context keeps pointing to the armature!
+        """
+
         print("Update Mesh name")
         for i in [i for i in bpy.context.selected_objects if i.name != context.active_object.name]:
             i.select = False

--- a/robot_designer_plugin/properties/globals.py
+++ b/robot_designer_plugin/properties/globals.py
@@ -220,9 +220,6 @@ class RDGlobals(PropertyGroupHandlerBase):
         self.mesh_name = PropertyHandler(StringProperty(update=self.update_geometry_name))
 
         # Holds the name of the currently selected physics frame (Empty object)
-        self.physics_frame_name = PropertyHandler(StringProperty())
-
-        # Holds the name of the currently selected physics frame (Empty object)
         self.camera_sensor_name = PropertyHandler(StringProperty())
 
         # Used to realize the main tab in the GUI

--- a/robot_designer_plugin/properties/objects.py
+++ b/robot_designer_plugin/properties/objects.py
@@ -65,12 +65,7 @@ class RDDynamics(bpy.types.PropertyGroup):
     # frame.RobotEditor.dynamics.CoM[2]))
     #    frame.location = position
 
-    # CoM = FloatVectorProperty(name = "Center of Mass", update=updateCoM, subtype = 'XYZ')
     mass = FloatProperty(name="Mass (kg)", precision=4, step=0.1, default=1.0)
-
-    # add inertia pose here
-    inertiaTrans = FloatVectorProperty(name="Translation", precision=4, step=0.1, default=[0.0, 0.0, 0.0])
-    inertiaRot = FloatVectorProperty(name="Rotation", precision=4, step=0.1, default=[0.0, 0.0, 0.0])
 
     # new inertia tensor
     inertiaXX = FloatProperty(name="", precision=4, step=0.1, default=1.0)

--- a/robot_designer_plugin/properties/segments.py
+++ b/robot_designer_plugin/properties/segments.py
@@ -71,8 +71,7 @@ class RDDegreeOfFreedom(bpy.types.PropertyGroup):
     def updateDoF(self: memoryview, context):
         if global_properties.do_kinematic_update.get(context.scene):
             segment_name = context.active_bone.name
-
-            UpdateSegments.run(segment_name=segment_name)
+            UpdateSegments.run(segment_name=segment_name, recurse=False)
 
     value = FloatProperty(name="Value", update=updateDoF, precision=4,
                           step=100)
@@ -158,14 +157,10 @@ class RDSegment(bpy.types.PropertyGroup):
     """
 
     def callbackSegments(self, context):
-        try:
-            logger.debug("Callback called")
-            armName = context.active_object.name
-            segment_name = context.active_bone.name
-
-            UpdateSegments.run(segment_name=segment_name)
-        except:
-            pass
+        armName = context.active_object.name
+        segment_name = context.active_bone.name
+        # We should not have to recurse when updating a local property.
+        UpdateSegments.run(segment_name=segment_name, recurse=False)
 
     def getTransform(self):
         """


### PR DESCRIPTION
Hi,

this is a set of changes for the latest sprint.
* The import segment function looks for meshes with vertex weights for the given bone and sets the bone_parent property accordingly. It also also disables the deform option, and prefixes the mesh names according to RD convention. This should have the same effect as if the mesh was manually assigned via RD to the bone.
* The mesh can be cloned to have both visual and collision geometry.
* I removed the mode selection button. Blender has a button for that already. In my default setup it is right under the RD button. So I saw no need for additional clutter.
* Overhauled the physics frame management: I assume that the user wants at most one physics frame per bone, and that there is little reason to ever detach and reassign it to another bone. Therefore:
* Removed assign, detach button. Instead ...
* Create button that creates the frame for all selected bones
* Compute from meshes button that calculates mass properties for selected bones. This is an extra button because one might first create the frame, then the mesh and then compute mass props.
* User can use the object tree to remove physics frames.
* Mass property gui will show props of the currently selected _bone_
* Removed selection dropdown for the physics frame objects. I found this not needed any longer.
There are a couple of additional bugfixes, for which I refer to the commit messages.
Video on owncloud showcasing the features: https://neurorobotics-files.net/owncloud/remote.php/webdav/review_demos/Sprint%2075/truphysics/robot-designer.mp4

Cheers