### PR TITLE
Dev

### DIFF
--- a/robot_designer_plugin/export/sdf/sdf_export.py
+++ b/robot_designer_plugin/export/sdf/sdf_export.py
@@ -65,6 +65,7 @@ from ...operators.helpers import ModelSelected, ObjectMode
 from ...operators.model import SelectModel
 from ..osim.osim_export import create_osim, get_muscles
 
+from ...properties.segments import getTransformFromBlender
 from ...properties.globals import global_properties
 
 from pyxb import ContentNondeterminismExceededError, BIND
@@ -204,7 +205,9 @@ def create_sdf(operator: RDOperator, context, filepath: str, meshpath: str, topl
         operator.logger.info("walk_segments: %s" % str(segment))
 
         child = tree.add()
-        trafo, dummy = segment.RobotEditor.getTransform()
+        trafo, _ = getTransformFromBlender(segment)
+
+
         # child.joint.origin.rpy = list_to_string(trafo.to_euler())
         # child.joint.origin.xyz = list_to_string([i * j for i, j in zip(trafo.translation, blender_scale_factor)])
 

--- a/robot_designer_plugin/export/urdf/urdf_export.py
+++ b/robot_designer_plugin/export/urdf/urdf_export.py
@@ -64,6 +64,7 @@ from ...core import config, PluginManager, RDOperator
 from ...operators.helpers import ModelSelected, ObjectMode
 from ...operators.model import SelectModel
 
+from ...properties.segments import getTransformFromBlender
 from ...properties.globals import global_properties
 
 def export_mesh(operator: RDOperator, context, name: str, directory: str, toplevel_dir: str, in_ros_package: bool,
@@ -171,7 +172,7 @@ def create_urdf(operator: RDOperator, context, base_link_name,
         :param tree: Reference to a URDF Tree object
         """
         child = tree.add()
-        trafo, dummy = segment.RobotEditor.getTransform()
+        trafo, _ = getTransformFromBlender(segment)
         child.joint.origin.rpy = list_to_string(trafo.to_euler())
         child.joint.origin.xyz = list_to_string([i * j for i, j in zip(trafo.translation, blender_scale_factor)])
 

--- a/robot_designer_plugin/interface/geometries.py
+++ b/robot_designer_plugin/interface/geometries.py
@@ -74,14 +74,30 @@ def draw(layout, context):
     row.label("Show:")
     global_properties.display_mesh_selection.prop(context.scene, row, expand=True)
 
+    if 1:
+        row = box.row()
+        column = row.column(align=True)
+        column.label("Segment Selector")
+        # Start of segment menu code.
+        single_segment = getSingleSegment(context)
+        column.menu(menus.SegmentsGeometriesMenu.bl_idname,
+                    text=single_segment.name if single_segment else "")
+        row2 = column.row(align=True)
+        global_properties.list_segments.prop(context.scene, row2, expand=True, icon_only=True)
+
+        global_properties.segment_name.prop_search(context.scene, row2, context.active_object.data, 'bones',
+                                                   icon='VIEWZOOM',
+                                                   text='')
+        # End of segment menu code.
+        column = row.column(align=True)
+        column.label("Mesh Selector")
+        menus.GeometriesMenu.putMenu(column, context)
+
+
     box = GeometrySettingsBox.get(layout, context, "Geometry Properties", icon="SCRIPTWIN")
     if box:
         infoBox = InfoBox(box)
         row = box.row()
-        column = row.column(align=True)
-        menus.GeometriesMenu.putMenu(column, context)
-        # create_geometry_selection(column, context)
-
         column = row.column(align=True)
         rigid_bodies.RenameAllGeometries.place_button(column, infoBox=infoBox)
         rigid_bodies.SetGeometryActive.place_button(column, infoBox=infoBox)
@@ -90,7 +106,7 @@ def draw(layout, context):
         selected_objects = [i for i in context.selected_objects if i.name != context.active_object.name]
         if len(selected_objects):
             obj = bpy.data.objects[global_properties.mesh_name.get(context.scene)]
-            box.prop(obj, "scale", slider=False, text="Scale")
+            box.prop(obj, "scale", slider=False, text="Scale (%s)" % obj.name)
             box.prop(selected_objects[0].RobotEditor, 'fileName')
 
         box.separator()
@@ -101,26 +117,23 @@ def draw(layout, context):
     if box:
         infoBox = InfoBox(box)
         row = box.row()
-        column = row.column(align=True)
 
+        # column = row.column(align=True)
+        # single_segment = getSingleSegment(context)
+        #
+        # column.menu(menus.SegmentsGeometriesMenu.bl_idname,
+        #             text=single_segment.name if single_segment else "Select Segment")
+        # row2 = column.row(align=True)
+        # global_properties.list_segments.prop(context.scene, row2, expand=True, icon_only=True)
+        #
+        # row2.separator()
+        #
+        # global_properties.segment_name.prop_search(context.scene, row2, context.active_object.data, 'bones',
+        #                  icon='VIEWZOOM',
+        #                  text='')
+        # column = row.column(align=True)
+        # menus.GeometriesMenu.putMenu(column, context)
 
-        single_segment = getSingleSegment(context)
-
-        column.menu(menus.SegmentsGeometriesMenu.bl_idname,
-                    text=single_segment.name if single_segment else "Select Segment")
-        row2 = column.row(align=True)
-
-        global_properties.list_segments.prop(context.scene, row2, expand=True, icon_only=True)
-        row2.separator()
-
-        global_properties.segment_name.prop_search(context.scene, row2, context.active_object.data, 'bones',
-                         icon='VIEWZOOM',
-                         text='')
-
-
-        column = row.column(align=True)
-        menus.GeometriesMenu.putMenu(column, context)
-        #create_geometry_selection(column, context)
 
         row = box.column(align=True)
         rigid_bodies.AssignGeometry.place_button(row, infoBox=infoBox)
@@ -134,8 +147,9 @@ def draw(layout, context):
     if box:
         infoBox = InfoBox(box)
         row = box.row()
-        column = row.column(align=True)
-        menus.GeometriesMenu.putMenu(column, context)
+
+        # column = row.column(align=True)
+        # menus.GeometriesMenu.putMenu(column, context)
         #create_geometry_selection(column, context)
 
         column = row.column(align=True)
@@ -151,9 +165,9 @@ def draw(layout, context):
         if box:
             infoBox = InfoBox(box)
             row = box.row()
-            column = row.column(align=True)
 
-            menus.GeometriesMenu.putMenu(column, context)
+            # column = row.column(align=True)
+            # menus.GeometriesMenu.putMenu(column, context)
             #create_geometry_selection(column, context)
             column = row.column(align=True)
             collision.GenerateAllCollisionMeshes.place_button(column, infoBox=infoBox)
@@ -168,8 +182,8 @@ def draw(layout, context):
     if box:
         infoBox = InfoBox(box)
         row = box.row()
-        column = row.column(align=True)
-        create_segment_selector(column, context)
+        # column = row.column(align=True)
+        # create_segment_selector(column, context)
         column = row.column(align=True)
         mesh_generation.GenerateMeshFromSegment.place_button(column, infoBox=infoBox)
         mesh_generation.GenerateMeshFromAllSegment.place_button(column,infoBox=infoBox)
@@ -181,8 +195,8 @@ def draw(layout, context):
     if box:
         infoBox = InfoBox(box)
         row = box.row()
-        column = row.column(align=True)
-        menus.GeometriesMenu.putMenu(column, context)
+        # column = row.column(align=True)
+        # menus.GeometriesMenu.putMenu(column, context)
         column = row.column(align=True)
         soft_bodies.ConvertSoftBodies.place_button(column, infoBox=infoBox)
         box.separator()
@@ -194,8 +208,8 @@ def draw(layout, context):
         infoBox = InfoBox(box)
         row = box.row()
         row.alignment = 'EXPAND'
-        column = row.column(align=True)
-        menus.GeometriesMenu.putMenu(column, context)
+        # column = row.column(align=True)
+        # menus.GeometriesMenu.putMenu(column, context)
         column = row.column(align=True)
 
         obj = bpy.data.objects[global_properties.mesh_name.get(context.scene)]

--- a/robot_designer_plugin/operators/collision.py
+++ b/robot_designer_plugin/operators/collision.py
@@ -220,10 +220,10 @@ class GenerateCollisionConvexHull(RDOperator):
     bl_idname = config.OPERATOR_PREFIX + "generateconvexhull"
     bl_label = "Generate convex hull for selected"
 
-
     @classmethod
     def run(cls):
         return super().run(**cls.pass_keywords())
+
     @RDOperator.OperatorLogger
     def execute(self, context):
         from . import segments, model
@@ -234,7 +234,7 @@ class GenerateCollisionConvexHull(RDOperator):
         armature = context.active_object.name
         
         cv_hull_obj_name = 'COL_' + target_name[4:] + "_convex_hull"
-        
+
         bpy.ops.object.select_all(action='DESELECT')
         
         exp_object = bpy.data.objects[target_name]
@@ -293,6 +293,8 @@ class GenerateCollisionConvexHull(RDOperator):
             to_delete = [f for f in bm.faces if not f in new]
             bmesh.ops.delete(bm, geom=to_delete, context=5)
 
+            bmesh.ops.recalc_face_normals(bm, faces = bm.faces)
+
             bm.to_mesh(collisionMesh)
             bm.free()
           
@@ -317,9 +319,10 @@ class GenerateCollisionConvexHull(RDOperator):
             bpy.ops.object.select_all(action='DESELECT')
             model.SelectModel.run(model_name=armature)
             segments.SelectSegment.run(segment_name=bpy.data.objects[target_name].parent_bone)
-            bpy.data.objects[name].select = True
+            bpy.data.objects[cv_hull_obj_name].select = True
             bpy.ops.object.parent_set(type='BONE', keep_transform=True)
             model.SelectModel.run(model_name=armature)
+
         except Exception as e:
             orig_object.name = target_name
             self.logger.info("Exception when computing convex hull")
@@ -328,6 +331,3 @@ class GenerateCollisionConvexHull(RDOperator):
             return{'CANCELLED'}
 
         return {'FINISHED'}
-
-    def invoke(self, context, event):
-        return context.window_manager.invoke_props_dialog(self)

--- a/robot_designer_plugin/operators/rigid_bodies.py
+++ b/robot_designer_plugin/operators/rigid_bodies.py
@@ -348,17 +348,19 @@ class ReduceAllGeometry(RDOperator):
         armature = context.active_object
 
         hide_geometry = global_properties.display_mesh_selection.get(context.scene)
-        geometry_names = [obj.name for obj in armature.children if
-                         not obj.parent_bone is None and
-                         obj.type == 'MESH']
+        meshes = [obj for obj in armature.children if
+                    obj.parent_bone is not None and obj.type == 'MESH']
 
-        meshes = [item.name for item in geometry_names if hide_geometry == 'collision' and item.RobotEditor.tag == 'COLLISION' if hide_geometry == 'visual' and item.RobotEditor.tag == 'DEFAULT']
+        if hide_geometry != 'all':
+            meshes = [item for item in meshes
+                      if (hide_geometry == 'collision' and item.RobotEditor.tag == 'COLLISION')
+                      or (hide_geometry == 'visual' and item.RobotEditor.tag == 'DEFAULT')]
 
-        if hide_geometry == 'all':
-            meshes = geometry_names
+        mesh_names = [ m.name for m in meshes ]
+        del meshes # Don't want to get into trouble with danling pointers again.
 
         ratio_act = bpy.data.objects[global_properties.mesh_name.get(context.scene)].modifiers["Decimate"].ratio
-        for selected_mesh in meshes:
+        for selected_mesh in mesh_names:
                 obj = bpy.data.objects[selected_mesh]
                 try:
                     obj.modifiers["Decimate"].ratio = ratio_act

--- a/robot_designer_plugin/properties/segments.py
+++ b/robot_designer_plugin/properties/segments.py
@@ -264,6 +264,18 @@ class RDSegment(bpy.types.PropertyGroup):
     Euler = PointerProperty(type=RDEulerAnglesSegment)  # Frame relative to parent
     DH = PointerProperty(type=RDDenavitHartenbergSegment)  # Dito but in a different way. Only one, either DH or Euler is used.
 
-# Resolving circular dependencies
 
-
+def getTransformFromBlender(bone):
+    # In whatever mode we currently are, get me a normal bpy.types.Bone.
+    #bone = bpy.context.active_object.data.bones[bone.name]
+    # On the other hand ...
+    assert isinstance(bone, bpy.types.Bone)
+    parent = bone.parent
+    if parent is not None:
+      pose_wrt_parent = parent.matrix_local.inverted() * bone.matrix_local
+    else:
+      pose_wrt_parent = bone.matrix_local
+    # Now, compute the joint Trafo. RD Applies the joint trafo to the pose bone.
+    # What is computed here as pose_wrt_parent refers to the edit bones.
+    _, joint_trafo = bone.RobotEditor.getTransform()
+    return pose_wrt_parent, joint_trafo


### PR DESCRIPTION
Could you add those patches, please.
"Fix operator to add simplification to all meshes. " and "Convex hull calculation: Automatically recalculate normals afterwards." are bugfixes.

Then, I suggest to "When exporting, give Blenders pose representation priority." This commit makes the exporter use the edit pose of bones instead of RD properties where RD stores it's own coordinate sets.

Also I think, the geometries tab was way too bloated with 5x redundant selection boxes. The last commit takes care of that.